### PR TITLE
empty rules can have attributes

### DIFF
--- a/R/rules.R
+++ b/R/rules.R
@@ -24,6 +24,8 @@ rule <- function(..., .lst = list(...), .string_as_fct = TRUE, .na_last = TRUE, 
   if (length(.lst) == 0) {
     res <- empty_rule
     attr(res, ".string_as_fct") <- .string_as_fct %||% TRUE
+    attr(res, ".drop") <- .drop %||% FALSE
+    attr(res, ".to_NA") <- .to_NA %||% NULL
     return(res)
   } else {
     .lst[is.na(.lst)] <- NA_character_
@@ -54,7 +56,9 @@ rule <- function(..., .lst = list(...), .string_as_fct = TRUE, .na_last = TRUE, 
 empty_rule <- structure(
   character(0L),
   class = c("empty_rule", "rule", "character"),
-  .string_as_fct = TRUE
+  .string_as_fct = TRUE,
+  .na_last = FALSE,
+  .drop = FALSE
 )
 
 #' @export
@@ -66,6 +70,7 @@ print.rule <- function(x, ...) {
     cat(nms[i], " <- ", if (length(x[[i]]) > 1) sprintf("[%s]", toString(x[[i]])) else x[[i]], "\n")
   }
   if (!is.null(attr(x, ".to_NA"))) cat("NA <- ", toString(attr(x, ".to_NA")), "\n")
+  cat("Convert to factor:", attr(x, ".string_as_fct"), "\n")
   cat("Drop unused level:", attr(x, ".drop"), "\n")
   cat("NA-replacing level in last position:", attr(x, ".na_last"), "\n")
 }
@@ -122,6 +127,9 @@ as.list.rule <- function(x, ...) {
 #' @export
 print.empty_rule <- function(x, ...) {
   cat("Empty mapping\n")
+  if (!is.null(attr(x, ".to_NA"))) cat("NA <- ", toString(attr(x, ".to_NA")), "\n")
+  cat("Convert to factor:", attr(x, ".string_as_fct"), "\n")
+  cat("Drop unused level:", attr(x, ".drop"), "\n")
 }
 
 #' Read `YAML` File describing `rule`

--- a/man/reformat.Rd
+++ b/man/reformat.Rd
@@ -53,6 +53,7 @@ format <- rule("A" = "a", "NN" = NA)
 
 reformat(obj, format)
 reformat(obj, format, .string_as_fct = FALSE, .to_NA = "x")
+reformat(obj, empty_rule, .string_as_fct = FALSE, .to_NA = "x")
 
 
 # Reformatting of factor.
@@ -62,6 +63,7 @@ format <- rule("A" = c("a", "aa"), "NN" = c(NA, "x"), "Not_present" = "z", "Not_
 
 reformat(obj, format)
 reformat(obj, format, .na_last = FALSE, .to_NA = "b", .drop = FALSE)
+reformat(obj, empty_rule, .na_last = FALSE, .to_NA = "b", .drop = FALSE)
 
 
 # Reformatting of list of data.frame.

--- a/tests/testthat/_snaps/rules.md
+++ b/tests/testthat/_snaps/rules.md
@@ -6,6 +6,7 @@
       Mapping of:
       a  <-  1 
       b  <-  NA 
+      Convert to factor: TRUE 
       Drop unused level: FALSE 
       NA-replacing level in last position: TRUE 
 
@@ -15,4 +16,15 @@
       empty_rule
     Output
       Empty mapping
+      Convert to factor: TRUE 
+      Drop unused level: FALSE 
+
+---
+
+    Code
+      empty_rule
+    Output
+      Empty mapping
+      Convert to factor: TRUE 
+      Drop unused level: FALSE 
 

--- a/tests/testthat/test-reformat.R
+++ b/tests/testthat/test-reformat.R
@@ -252,7 +252,7 @@ test_that("reformat for list works for empty rule", {
 
 # reformat using empty_rule ----
 
-test_that("empty_rule do nothing to input", {
+test_that("by default, empty_rule only converts input to factor", {
   a <- c("1", "2")
   expect_identical(as.factor(a), reformat(a, empty_rule))
 
@@ -261,4 +261,24 @@ test_that("empty_rule do nothing to input", {
 
   b <- factor(c("1", "2"))
   expect_identical(b, reformat(b, empty_rule))
+})
+
+test_that("empty_rule can use attribute to modify input", {
+  x <- c("b", "a", "b", "", NA, "a")
+  r <- rule(.to_NA = "b", .string_as_fct = FALSE)
+  expected <- c(NA, "a", NA, "", NA, "a")
+  res <- reformat(x, r)
+  expect_identical(res, expected)
+
+  x <- factor(c("a", "a", "b", "", NA), levels = c("a", "b", "", "Absent"))
+  r <- rule(.to_NA = "b")
+  expected <- factor(c("a", "a", NA, "", NA), levels = c("a", "", "Absent"))
+  res <- reformat(x, r)
+  expect_identical(res, expected)
+
+  x <- factor(c("a", "a", "b", "", NA), levels = c("a", "b", "", "Absent"))
+  r <- rule(.to_NA = "b", .drop = TRUE)
+  expected <- factor(c("a", "a", NA, "", NA), levels = c("a", ""))
+  res <- reformat(x, r)
+  expect_identical(res, expected)
 })

--- a/tests/testthat/test-rules.R
+++ b/tests/testthat/test-rules.R
@@ -46,10 +46,36 @@ test_that("rule printed correctly", {
 
 test_that("emtpy_rule is length 0 character", {
   expect_identical(empty_rule, character(0), ignore_attr = TRUE)
+  att <- attributes(empty_rule)
+  expect_true(att$.string_as_fct)
+  expect_false(att$.drop)
+  expect_null(att$.to_NA)
 })
 
 test_that("emtpy_rule printed correctly", {
   expect_snapshot(empty_rule)
+})
+
+test_that("emtpy_rule printed correctly", {
+  expect_snapshot(empty_rule)
+})
+
+test_that("emtpy_rule can be created with a call to rule", {
+  r <- rule()
+  expect_identical(r, character(0), ignore_attr = TRUE)
+  att <- attributes(r)
+  expect_true(att$.string_as_fct)
+  expect_false(att$.drop)
+  expect_null(att$.to_NA)
+})
+
+test_that("emtpy_rule attributes can be set with a call to rule", {
+  r <- rule(.drop = TRUE, .string_as_fct = FALSE, .to_NA = "x")
+  expect_identical(r, character(0), ignore_attr = TRUE)
+  att <- attributes(r)
+  expect_false(att$.string_as_fct)
+  expect_true(att$.drop)
+  expect_identical(att$.to_NA, "x")
 })
 
 # list2rules ----


### PR DESCRIPTION
enable the usage of attributes with empty_rule to allow things like
```
> x = c("a", "")
> reformat(x, rule(.to_NA = ""))
[1] a    <NA>
Levels: a
```

thank you for the review