### PR TITLE
strict tests; enhancements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 Collate:
     'assertions.R'
     'co_relevels.R'

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -21,7 +21,7 @@ assert_valid_format <- function(object) {
   coll <- checkmate::makeAssertCollection()
 
   # Check object.
-  checkmate::assert_list(object, names = "unique", type = "list", add = coll)
+  checkmate::assert_list(object, names = "unique", types = "list", add = coll)
 
   # Check table level.
   mapply(
@@ -65,7 +65,7 @@ assert_valid_list_format <- function(object) {
   coll <- checkmate::makeAssertCollection()
 
   # Check object.
-  checkmate::assert_list(object, names = "unique", type = "list", add = coll)
+  checkmate::assert_list(object, names = "unique", types = "list", add = coll)
 
   # Check table level.
   mapply(
@@ -92,7 +92,7 @@ assert_valid_list_format <- function(object) {
           checkmate::assert_list(
             x,
             names = "unique",
-            type = c("character", "numeric", "logical"),
+            types = c("character", "numeric", "logical"),
             .var.name = paste0("[", xtable, ".", xvar, "]"),
             add = coll
           )

--- a/R/explicit_na.R
+++ b/R/explicit_na.R
@@ -12,7 +12,6 @@
 #' @export
 #'
 #' @examples
-#'
 #' df1 <- data.frame(
 #'   "char" = c("a", "b", NA, "a", "k", "x"),
 #'   "char2" = c("A", "B", NA, "A", "K", "X"),

--- a/R/reformat.R
+++ b/R/reformat.R
@@ -35,7 +35,6 @@ reformat.default <- function(obj, format, ...) {
 #' @rdname reformat
 #'
 #' @examples
-#'
 #' # Reformatting of character.
 #' obj <- c("a", "b", "x", NA, "")
 #' attr(obj, "label") <- "my label"
@@ -76,7 +75,6 @@ reformat.character <- function(obj, format, ...) {
 #' @rdname reformat
 #'
 #' @examples
-#'
 #' # Reformatting of factor.
 #' obj <- factor(c("first", "a", "aa", "b", "x", NA), levels = c("first", "x", "b", "aa", "a", "z"))
 #' attr(obj, "label") <- "my label"
@@ -127,7 +125,6 @@ reformat.factor <- function(obj, format, ...) {
 #'   data set except where another rule is specified for the same variable under a specific data set name.
 #'
 #' @examples
-#'
 #' # Reformatting of list of data.frame.
 #' df1 <- data.frame(
 #'   var1 = c("a", "b", NA),

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pak::pak("insightsengineering/dunlin")
   4    a <NA>   d
   5    k   f1   e
   6    x   f1   f
-  
+
   $df2
       id  id2 num val
   1    a   f1   1   a
@@ -90,7 +90,7 @@ pak::pak("insightsengineering/dunlin")
     )
   )
 
-  res <- dunlin::reformat(prop_db, new_format, .na_last = TRUE)
+  res <- reformat(prop_db, new_format, .na_last = TRUE)
 
   ```
 
@@ -105,7 +105,7 @@ pak::pak("insightsengineering/dunlin")
   4               a <Missing>   d
   5               k        f1   e
   6               x        f1   f
-  
+
   $df2
       id  id2 num val
   1    a   f1   1   a

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,5 +1,6 @@
+dunlin
 Forkers
-Hoffmann
 funder
+Hoffmann
 preprocess
 repo

--- a/man/ls_explicit_na.Rd
+++ b/man/ls_explicit_na.Rd
@@ -34,7 +34,6 @@ This is a helper function to encode missing values (i.e \code{NA} and \verb{empt
 \code{factor} variable found in a \code{list} of \code{data.frame}. The \code{label} attribute of the columns is preserved.
 }
 \examples{
-
 df1 <- data.frame(
   "char" = c("a", "b", NA, "a", "k", "x"),
   "char2" = c("A", "B", NA, "A", "K", "X"),

--- a/man/reformat.Rd
+++ b/man/reformat.Rd
@@ -51,7 +51,6 @@ the variables listed under the \code{all_dataset} keyword will be reformatted wi
 data set except where another rule is specified for the same variable under a specific data set name.
 }
 \examples{
-
 # Reformatting of character.
 obj <- c("a", "b", "x", NA, "")
 attr(obj, "label") <- "my label"
@@ -60,7 +59,6 @@ format <- rule("A" = "a", "NN" = NA)
 reformat(obj, format)
 reformat(obj, format, .string_as_fct = FALSE, .to_NA = NULL)
 
-
 # Reformatting of factor.
 obj <- factor(c("first", "a", "aa", "b", "x", NA), levels = c("first", "x", "b", "aa", "a", "z"))
 attr(obj, "label") <- "my label"
@@ -68,7 +66,6 @@ format <- rule("A" = c("a", "aa"), "NN" = c(NA, "x"), "Not_present" = "z", "Not_
 
 reformat(obj, format)
 reformat(obj, format, .na_last = FALSE, .to_NA = "b", .drop = FALSE)
-
 
 # Reformatting of list of data.frame.
 df1 <- data.frame(

--- a/tests/testthat/setup-options.R
+++ b/tests/testthat/setup-options.R
@@ -1,0 +1,17 @@
+opts_partial_match_old <- list(
+  warnPartialMatchDollar = getOption("warnPartialMatchDollar"),
+  warnPartialMatchArgs = getOption("warnPartialMatchArgs"),
+  warnPartialMatchAttr = getOption("warnPartialMatchAttr")
+)
+opts_partial_match_new <- list(
+  warnPartialMatchDollar = TRUE,
+  warnPartialMatchArgs = TRUE,
+  warnPartialMatchAttr = TRUE
+)
+
+if (isFALSE(getFromNamespace("on_cran", "testthat")()) && require("withr")) {
+  withr::local_options(
+    opts_partial_match_new,
+    .local_envir = testthat::teardown_env()
+  )
+}

--- a/tests/testthat/test-render_safe.R
+++ b/tests/testthat/test-render_safe.R
@@ -15,8 +15,8 @@ test_that("add_whisker and remove_whisker works", {
   expect_identical(get("a", envir = whisker_env), c(a = "1"))
   expect_identical(get("b", envir = whisker_env), c(b = "2"))
   remove_whisker(c("a", "b"))
-  expect_false(exists("a", envir = whisker_env, inherit = FALSE))
-  expect_false(exists("b", envir = whisker_env, inherit = FALSE))
+  expect_false(exists("a", envir = whisker_env, inherits = FALSE))
+  expect_false(exists("b", envir = whisker_env, inherits = FALSE))
   expect_error(add_whisker(c(a = "1", b = list())))
 })
 

--- a/vignettes/Reformatting.Rmd
+++ b/vignettes/Reformatting.Rmd
@@ -27,7 +27,7 @@ This is performed in two steps:
 
 1. A Reformatting Map (`rule` object) is created which specifies the correspondence between the old and the new values
 
-2. The reformatting itself is performed with the `dunlin::reformat()` function.
+2. The reformatting itself is performed with the `reformat()` function.
 
 ## The Formatting Map Structure
 


### PR DESCRIPTION
- part of https://github.com/insightsengineering/coredev-tasks/issues/478
- fixes discovered partial argument matches
- removed `citril::` prefix as this is redundant in docs within `dunlin`
- removed unnecessary empty first line in examples as this is actually being rendered

Please review the changes carefully and let me know if there is something you don't like.