### PR TITLE
163 since format is printed, we may want to improve how formats are printed, currently it is

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 * Rules specified under the `all_datasets` keyword in a format list will apply to every data set of the reformatted object unless specified otherwise.
 * New `verbose` argument in the `reformat` method. When applied to `list` the value of this augment can be controlled with the `dunlin.reformat.verbose` option or the `R_DUNLIN_REFORMAT_VERBOSE` environment variable.
-
+* Improve the output when printing `rule` objects.
+ 
 # dunlin 0.1.6
 
 * `render_safe` now renders placeholder using in priority values corresponding to the key matching exactly the placeholder, case included.

--- a/R/rules.R
+++ b/R/rules.R
@@ -52,12 +52,16 @@ print.rule <- function(x, ...) {
   if (length(x) == 0) {
     cat("Empty mapping.\n")
   } else {
-    for (i in seq_len(length(x))) {
-      cat(nms[i], " <- ", if (length(x[[i]]) > 1) sprintf("[%s]", toString(x[[i]])) else x[[i]], "\n")
+    for (i in seq_along(x)) {
+      ori_nms <- if (length(x[[i]]) > 1) sprintf("[%s]", toString(x[[i]])) else x[[i]]
+      ori_nms <- ifelse(is.na(ori_nms), "<NA>", shQuote(ori_nms))
+      cat(nms[i], " <- ", ori_nms, "\n")
     }
   }
   .to_NA <- attr(x, ".to_NA")
-  if (!is.null(.to_NA)) cat("NA <- ", toString(.to_NA), "\n")
+  if (!is.null(.to_NA)) {
+    cat("Convert to <NA>:", toString(shQuote(.to_NA)), "\n")
+  }
   cat("Convert to factor:", attr(x, ".string_as_fct"), "\n")
   cat("Drop unused level:", attr(x, ".drop"), "\n")
   cat("NA-replacing level in last position:", attr(x, ".na_last"), "\n")

--- a/R/rules.R
+++ b/R/rules.R
@@ -54,13 +54,13 @@ print.rule <- function(x, ...) {
   } else {
     for (i in seq_along(x)) {
       ori_nms <- if (length(x[[i]]) > 1) sprintf("[%s]", toString(x[[i]])) else x[[i]]
-      ori_nms <- ifelse(is.na(ori_nms), "<NA>", shQuote(ori_nms))
+      ori_nms <- ifelse(is.na(ori_nms), "<NA>", stringr::str_c("\"", ori_nms, "\""))
       cat(nms[i], " <- ", ori_nms, "\n")
     }
   }
   .to_NA <- attr(x, ".to_NA")
   if (!is.null(.to_NA)) {
-    cat("Convert to <NA>:", toString(shQuote(.to_NA)), "\n")
+    cat("Convert to <NA>:", toString(stringr::str_c("\"", .to_NA, "\"")), "\n")
   }
   cat("Convert to factor:", attr(x, ".string_as_fct"), "\n")
   cat("Drop unused level:", attr(x, ".drop"), "\n")

--- a/tests/testthat/_snaps/rules.md
+++ b/tests/testthat/_snaps/rules.md
@@ -11,3 +11,20 @@
       Drop unused level: FALSE 
       NA-replacing level in last position: TRUE 
 
+# rule with multiple matching printed correctly
+
+    Code
+      rule(a = "1", b = c(NA, "b"), x = c("first", "second"), .to_NA = c("",
+        "missing"))
+    Output
+      Mapping of:
+      a  <-  "1" 
+      b  <-  <NA> 
+      b  <-  "b" 
+      x  <-  "first" 
+      x  <-  "second" 
+      Convert to <NA>: "", "missing" 
+      Convert to factor: TRUE 
+      Drop unused level: FALSE 
+      NA-replacing level in last position: TRUE 
+

--- a/tests/testthat/_snaps/rules.md
+++ b/tests/testthat/_snaps/rules.md
@@ -4,9 +4,9 @@
       rule(a = "1", b = NA)
     Output
       Mapping of:
-      a  <-  1 
-      b  <-  NA 
-      NA <-   
+      a  <-  "1" 
+      b  <-  <NA> 
+      Convert to <NA>: "" 
       Convert to factor: TRUE 
       Drop unused level: FALSE 
       NA-replacing level in last position: TRUE 

--- a/tests/testthat/test-rules.R
+++ b/tests/testthat/test-rules.R
@@ -122,5 +122,3 @@ test_that("as.list and rule are reversible when .to_NA is NULL", {
   test_rule <- rule(a = c("a", "b"), b = c("c", "d"), .drop = FALSE, .na_last = TRUE, .to_NA = NULL)
   expect_identical(do.call(rule, as.list(test_rule)), test_rule)
 })
-
-

--- a/tests/testthat/test-rules.R
+++ b/tests/testthat/test-rules.R
@@ -38,8 +38,14 @@ test_that("rule fails for values that is not character/logical/numeric", {
   )
 })
 
+# print ----
+
 test_that("rule printed correctly", {
   expect_snapshot(rule(a = "1", b = NA))
+})
+
+test_that("rule with multiple matching printed correctly", {
+  expect_snapshot(rule(a = "1", b = c(NA, "b"), x = c("first", "second"), .to_NA = c("", "missing")))
 })
 
 # list2rules ----
@@ -116,3 +122,5 @@ test_that("as.list and rule are reversible when .to_NA is NULL", {
   test_rule <- rule(a = c("a", "b"), b = c("c", "d"), .drop = FALSE, .na_last = TRUE, .to_NA = NULL)
   expect_identical(do.call(rule, as.list(test_rule)), test_rule)
 })
+
+


### PR DESCRIPTION
https://github.com/insightsengineering/dunlin/issues/163

close #163 

Improve the print method to display `<NA>` when the value is `NA` and surround strings with `"` to highlight the fact that they are character and allow to better visualize with spaces.

thank you for the review