### PR TITLE
Trim reformat log@main

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dunlin 0.1.9.9002
 
+* The log printed by `reformat` when `verbose = TRUE` is limited to the tables and column existing in the reformatted data set.
+
 # dunlin 0.1.9
 
 * Change package maintainer to Joe Zhu.

--- a/R/reformat.R
+++ b/R/reformat.R
@@ -154,6 +154,9 @@ reformat.factor <- function(obj, format, ..., verbose = FALSE) {
 #'   df2 = list(
 #'     var2 = rule("f11" = "F11", "NN" = NA)
 #'   ),
+#'   df_absent = list(
+#'     var1 = rule("NO" = "no")
+#'   ),
 #'   all_datasets = list(
 #'     var1 = rule("xx" = "x", "aa" = "a")
 #'   )
@@ -180,8 +183,8 @@ reformat.list <- function(obj,
   format <- h_expand_all_datasets(format, ls_datasets)
 
   if (verbose) {
-    for (tb in names(format)) {
-      for (cl in names(format[[tb]])) {
+    for (tb in intersect(names(format), ls_datasets)) {
+      for (cl in intersect(names(format[[tb]]), colnames(obj[[tb]]))) {
         cat(sprintf("\nData frame `%s`, column `%s`:\n", tb, cl))
         print(format[[tb]][[cl]])
       }

--- a/tests/testthat/test-reformat.R
+++ b/tests/testthat/test-reformat.R
@@ -380,6 +380,34 @@ test_that("reformat for list works as expected when verbose is TRUE", {
   expect_identical(out[12:19], expected)
 })
 
+test_that("reformat for list works as expected when verbose is TRUE and tables are missing", {
+  df1 <- data.frame(
+    "char" = c("", "b", NA, "a", "k", "x"),
+    "fact" = factor(c("f1", "f2", NA, NA, "f1", "f1"), levels = c("f2", "f1"))
+  )
+  df2 <- data.frame(
+    "char" = c("a", "b", NA, "a", "k", "x"),
+    "fact" = factor(c("f1", "f2", NA, NA, "f1", "f1")),
+    "another_char" = c("a", "b", NA, "a", "k", "x"),
+    "another_fact" = factor(c("f1", "f2", NA, NA, "f1", "f1"))
+  )
+  
+  db <- list(df1 = df1, df2 = df2)
+  attr(db$df1$char, "label") <- "my label"
+  
+  test_map <- list(
+    df1 = list(
+      absent = rule("Empty" = "", "B" = "b", "Not Available" = NA)
+    ),
+    df_absent = list(
+      char = rule()
+    )
+  )
+  
+  out <- capture.output(res <- reformat(db, test_map, verbose = TRUE))
+  expect_identical(out, "")
+})
+
 # h_expand_all_datasets ----
 
 test_that("h_expand_all_datasets works as expected", {


### PR DESCRIPTION
reformat was printing all the rules including the ones that do not apply to the refomatted data set because tables and/or variables are missing.

thank you for the review